### PR TITLE
Add shorter method for get the ip of the Request

### DIFF
--- a/index.html
+++ b/index.html
@@ -1252,7 +1252,7 @@ Request::path();
 // getRequestUri: /aa/bb/?c=d
 Request::getRequestUri();
 // Returns user's IP
-Request::getClientIp();
+Request::ip();
 // getUri: http://xx.com/aa/bb/?c=d
 Request::getUri();
 // getQueryString: c=d


### PR DESCRIPTION
Hello! Great project!
I would like contribute with this method:

``` php
Request::ip();
```

It's a wrapper of the Symfony method:

``` php
Request::getClientIp();
```

You can find it on the Laravel docs:
https://laravel.com/api/5.2/Illuminate/Http/Request.html#method_ip

Thanks!
